### PR TITLE
[#65] Hotfix: use older versions of scriptlets and uBlock filters so YouTube ads are blocked again.

### DIFF
--- a/src/main/java/org/eblocker/lists/easylist/DownloadLists.java
+++ b/src/main/java/org/eblocker/lists/easylist/DownloadLists.java
@@ -56,7 +56,7 @@ public class DownloadLists {
 			if (list.hasChecksum()) {
 				verifyListChecksum(filename);
 			}
-			verifyListAge(filename);
+			verifyListAge(filename, list.getMaxAgeDays());
 			MaxFilterSizeValidator.verifyFilterSize(list);
 			EasyListSyntaxValidator.verifyAndRepair(list);
 		}
@@ -71,10 +71,10 @@ public class DownloadLists {
 		}
 	}
 
-	private static void verifyListAge(String filename) throws IOException, ParseException {
+	private static void verifyListAge(String filename, int maxAgeDaysOverride) throws IOException, ParseException {
 		MaxAgeValidator validator = new MaxAgeValidator();
 		FileInputStream input = new FileInputStream(filename);
-		MaxAgeValidationResult result = validator.validate(input, new Date());
+		MaxAgeValidationResult result = validator.validate(input, new Date(), maxAgeDaysOverride);
 		switch (result) {
 			case OK:
 				break;

--- a/src/main/java/org/eblocker/lists/easylist/EasyListConfiguration.java
+++ b/src/main/java/org/eblocker/lists/easylist/EasyListConfiguration.java
@@ -47,7 +47,8 @@ public class EasyListConfiguration {
 			String filename = directory + "/" + getListParameter(list, "filename");
 			String url = getListParameter(list, "url");
 			long minimumBytesJSON = Long.parseLong(getListParameter(list, "minimum_bytes_json"));
-			int maxAgeDays = Integer.parseInt(getListParameter(list, "max_age_days"));
+			String maxAgeDaysStr = getListParameter(list, "max_age_days");
+			int maxAgeDays = maxAgeDaysStr != null ? Integer.parseInt(maxAgeDaysStr) : 0;
 			String hasChecksumValue = getListParameter(list, "has_checksum");
 			boolean hasChecksum = hasChecksumValue == null ? true : Boolean.parseBoolean(hasChecksumValue);
 			Set<EasyListRuleTest> easyListRuleTests = new HashSet<>();

--- a/src/main/resources/lists.properties
+++ b/src/main/resources/lists.properties
@@ -6,39 +6,34 @@ list.max_filter_size=80000
 list.easyprivacy.url=https://easylist-downloads.adblockplus.org/easyprivacy.txt
 list.easyprivacy.filename=easyprivacy.txt_src
 list.easyprivacy.minimum_bytes_json=7000000
-list.easyprivacy.max_age_days=1
 list.easyprivacy.ruletest.1 = rule_test_eblocker.csv
 list.easyprivacy.ruletest.2 = rule_tests_alexa_top10_de.txt
 
 list.easylist.url=https://easylist-downloads.adblockplus.org/easylist.txt
 list.easylist.filename=easylist.txt_src
 list.easylist.minimum_bytes_json=17000000
-list.easylist.max_age_days=1
 list.easylist.ruletest.1 = rule_test_eblocker.csv
 list.easylist.ruletest.2 = rule_tests_alexa_top10_de.txt
 
 list.easylistgermany.url=https://easylist-downloads.adblockplus.org/easylistgermany.txt
 list.easylistgermany.filename=easylistgermany.txt_src
 list.easylistgermany.minimum_bytes_json=1000000
-list.easylistgermany.max_age_days=1
 list.easylistgermany.ruletest.1 = rule_test_eblocker.csv
 list.easylistgermany.ruletest.2 = rule_tests_alexa_top10_de.txt
 
 list.easylistcookie.url=https://secure.fanboy.co.nz/fanboy-cookiemonster.txt
 list.easylistcookie.filename=easylist-cookie.txt_src
 list.easylistcookie.minimum_bytes_json=2000000
-list.easylistcookie.max_age_days=1
 list.easylistcookie.ruletest.1 = rule_test_eblocker.csv
 list.easylistcookie.ruletest.2 = rule_tests_alexa_top10_de.txt
 
 list.ddgtr.url=https://raw.githubusercontent.com/eblocker/ddg-tr-as-easylist/eblocker/easylist/ALL/forEblocker.txt
 list.ddgtr.filename=ddgtr.txt_src
 list.ddgtr.minimum_bytes_json=0
-list.ddgtr.max_age_days=100
 list.ddgtr.ruletest.1 = rule_test_eblocker.csv
 list.ddgtr.ruletest.2 = rule_tests_alexa_top10_de.txt
 
-list.ubofilters.url=https://raw.githubusercontent.com/uBlockOrigin/uAssets/gh-pages/filters/filters.txt
+list.ubofilters.url=https://raw.githubusercontent.com/uBlockOrigin/uAssets/ff7c8e1084b0c83ddcb00a18d6d1285c6af3a816/filters/filters.txt
 list.ubofilters.filename=ubofilters.txt_src
 list.ubofilters.minimum_bytes_json=0
 list.ubofilters.max_age_days=100

--- a/src/main/resources/scriptlets.properties
+++ b/src/main/resources/scriptlets.properties
@@ -1,2 +1,3 @@
 scriptlets.directory = scriptlets
-scriptlets.url = https://raw.githubusercontent.com/gorhill/uBlock/master/assets/resources/scriptlets.js
+scriptlets.url = https://raw.githubusercontent.com/gorhill/uBlock/e93117cbb607472a830e1c0653dfbddde4c965fc/assets/resources/scriptlets.js
+scriptlets.minimum_number = 20

--- a/src/test/resources/easylist-expires-missing.txt
+++ b/src/test/resources/easylist-expires-missing.txt
@@ -1,0 +1,10 @@
+[Adblock Plus x.y]
+! Updated: 2021-03-10 09:00 UTC
+This
+list
+does
+not
+have
+an
+"Expires"
+header

--- a/src/test/resources/easylist-last-modified-missing.txt
+++ b/src/test/resources/easylist-last-modified-missing.txt
@@ -1,0 +1,10 @@
+[Adblock Plus x.y]
+! Expires: 9 days (update frequency)
+This
+list
+does
+not
+have
+a
+"Last Modified"
+header


### PR DESCRIPTION
Throw an error if too few scriplets can be parsed. Optionally override the maximum age of EasyLists.