### PR TITLE
get icap server lib from github

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-ssettings.xml

--- a/.run/eblocker-lists [package,-Pupdate-lists...].run.xml
+++ b/.run/eblocker-lists [package,-Pupdate-lists...].run.xml
@@ -1,0 +1,34 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="eblocker-lists [package,-Pupdate-lists...]" type="MavenRunConfiguration" factoryName="Maven" nameIsGenerated="true">
+    <MavenSettings>
+      <option name="myGeneralSettings" />
+      <option name="myRunnerSettings" />
+      <option name="myRunnerParameters">
+        <MavenRunnerParameters>
+          <option name="cmdOptions" />
+          <option name="profiles">
+            <set />
+          </option>
+          <option name="goals">
+            <list>
+              <option value="package" />
+              <option value="-Pupdate-lists" />
+              <option value="-Dmaven.test.skip=true" />
+            </list>
+          </option>
+          <option name="multimoduleDir" />
+          <option name="pomFileName" />
+          <option name="profilesMap">
+            <map />
+          </option>
+          <option name="projectsCmdOptionValues">
+            <list />
+          </option>
+          <option name="resolveToWorkspace" value="false" />
+          <option name="workingDirPath" value="$PROJECT_DIR$" />
+        </MavenRunnerParameters>
+      </option>
+    </MavenSettings>
+    <method v="2" />
+  </configuration>
+</component>

--- a/pom.xml
+++ b/pom.xml
@@ -18,11 +18,23 @@
       <version.slf4j>1.7.32</version.slf4j>
       <version.log4j2>2.17.1</version.log4j2>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>eblocker</id>
+            <url>https://maven.pkg.github.com/P8hJ/eblocker</url>
+        </repository>
+        <repository>
+            <id>eblocker-top</id>
+            <url>https://maven.pkg.github.com/eblocker/eblocker-top</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.eblocker</groupId>
             <artifactId>eblocker-icapserver</artifactId>
-            <version>3.0.0</version>
+            <version>3.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <repositories>
         <repository>
             <id>eblocker</id>
-            <url>https://maven.pkg.github.com/P8hJ/eblocker</url>
+            <url>https://maven.pkg.github.com/eblocker/eblocker</url>
         </repository>
         <repository>
             <id>eblocker-top</id>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.eblocker</groupId>
             <artifactId>eblocker-icapserver</artifactId>
-            <version>3.1-SNAPSHOT</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,23 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <servers>
+        <server>
+            <id>eblocker</id>
+            <username>NoUserName</username>
+            <password>&#103;hp_qvFkXg88QTr6vnGx3OmTDPFvB14HCu2ysnEN</password>
+        </server>
+        <server>
+            <id>eblocker-top</id>
+            <username>NoUserName</username>
+            <password>&#103;hp_Cei0Aao5u77MAOxJu7Hlwc1piSERTk3rv8Pt</password>
+        </server>
+        <server>
+            <id>netty-icap</id>
+            <username>NoUserName</username>
+            <password>&#103;hp_Cei0Aao5u77MAOxJu7Hlwc1piSERTk3rv8Pt</password>
+        </server>
+    </servers>
+</settings>


### PR DESCRIPTION
With these changes, a launcher is now available in IntellIj to execute the Maven command to update the list (mvn package -Pupdate-lists). In addition, the jars that are needed are taken directly from github and no longer have to be built locally